### PR TITLE
Version 1.0.4-1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,7 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Collate: 
     'api.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: goodpractice
 Title: Advice on R Package Building
-Version: 1.0.3
+Version: 1.0.4-1
 Authors@R:
     c(person(given = "Ascent Digital Services UK Limited",
              role = "cph",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Description: Give advice about good practices when building R packages.
     Advice includes functions and syntax to avoid, package structure, code
     complexity, code formatting, etc.
 License: MIT + file LICENSE
-URL: https://github.com/mangothecat/goodpractice
+URL: https://mangothecat.github.io/goodpractice/, https://github.com/mangothecat/goodpractice
 BugReports: https://github.com/mangothecat/goodpractice/issues
 Imports:
     clisymbols,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# goodpractice 1.0.4-1
+
+* CRAN fixes - skipping failing test and updating roxygen
+* Adding pkgdown site to DESCRIPTION (#160, @olivroy)
+
 # goodpractice 1.0.3
 
 Additions:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # goodpractice 1.0.4-1
 
-* CRAN fixes - skipping failing test and updating roxygen
+* CRAN fixes - skipping failing test and adding \alias{goodpractice} to package Rd
 * Adding pkgdown site to DESCRIPTION (#160, @olivroy)
 
 # goodpractice 1.0.3

--- a/man/customization.Rd
+++ b/man/customization.Rd
@@ -34,11 +34,11 @@ Defining custom preparations and checks
 }
 \section{Functions}{
 \itemize{
-\item \code{make_prep}: Create a preparation function
+\item \code{make_prep()}: Create a preparation function
 
-\item \code{make_check}: Create a check function
+\item \code{make_check()}: Create a check function
+
 }}
-
 \examples{
 # make a preparation function
 url_prep <- make_prep(

--- a/man/goodpractice-package.Rd
+++ b/man/goodpractice-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/package.R
 \docType{package}
 \name{goodpractice-package}
+\alias{goodpractice-package}
 \title{goodpractice: Advice on R Package Building}
 \description{
 Give advice about good practices when building R packages. Advice includes
@@ -11,6 +12,7 @@ formatting, etc.
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://mangothecat.github.io/goodpractice/}
   \item \url{https://github.com/mangothecat/goodpractice}
   \item Report bugs at \url{https://github.com/mangothecat/goodpractice/issues}
 }


### PR DESCRIPTION
Fixes for CRAN:
- Test fix made for version 1.0.4 (but poorly recorded in github) more to be done here at a later date see #157 
- Re-document package to add `\alias{goodpractice}` in package Rd

Additions:
- Adding pkgdown site to DESCRIPTION (#160, @olivroy) 