### PR TITLE
Add to admonishment against import(<pkg>) usage

### DIFF
--- a/R/chk_namespace.R
+++ b/R/chk_namespace.R
@@ -8,7 +8,7 @@ CHECKS$no_import_package_as_a_whole <- make_check(
   preps = "namespace",
 
   gp = 'not import packages as a whole, as this can cause name
-        clashes between the imported packages, especially over time.
+        clashes between the imported packages, especially over time as packages change.
         Instead, import only the specific functions you need.',
 
   check = function(state) {

--- a/R/chk_namespace.R
+++ b/R/chk_namespace.R
@@ -8,8 +8,8 @@ CHECKS$no_import_package_as_a_whole <- make_check(
   preps = "namespace",
 
   gp = 'not import packages as a whole, as this can cause name
-        clashes between the imported packages. Instead, import
-        only the specific functions you need.',
+        clashes between the imported packages, especially over time.
+        Instead, import only the specific functions you need.',
 
   check = function(state) {
     if(inherits(state$namespace, "try-error")) return(NA)


### PR DESCRIPTION
One common way for `import(<pkg>)` to bite IME is as upstream packages add new exported functions.